### PR TITLE
Show panel participants at mobile breakpoint

### DIFF
--- a/app/sass/app.scss
+++ b/app/sass/app.scss
@@ -460,9 +460,6 @@ form select {
 				margin: 0;
 				border-right: 0;
 			}
-			.participant {
-				display: none;
-			}
 		}
 	}
 }


### PR DESCRIPTION
This has been bugging me and a few others.. When we've gone to check who is on a panel whilst viewing on a mobile device to find nothing :sadpandaface: 

I envision a lot of people doing this on the day. What was the reasoning for hiding them in the first place?
### iPhone 5 example:

![google chrome](https://cloud.githubusercontent.com/assets/80089/8340044/c16adbd4-1ab3-11e5-8250-f3f944f88523.png)
